### PR TITLE
fix(sensor): per-probe area and ambient sensors (fixes #5, #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,12 +110,14 @@ sensor.thermomaven_[device]_probe_4          # Probe 4 temperature (if available
 
 #### 🔥 Zone Sensors (for each probe)
 
+One set per probe (N = 1 to the number of probes on your device):
+
 ```
-sensor.thermomaven_[device]_area_1_tip       # Zone 1 (Tip)
-sensor.thermomaven_[device]_area_2           # Zone 2
-sensor.thermomaven_[device]_area_3           # Zone 3
-sensor.thermomaven_[device]_area_4           # Zone 4
-sensor.thermomaven_[device]_area_5_handle    # Zone 5 (Handle)
+sensor.thermomaven_[device]_probe_N_area_1_tip       # Probe N Zone 1 (Tip)
+sensor.thermomaven_[device]_probe_N_area_2           # Probe N Zone 2
+sensor.thermomaven_[device]_probe_N_area_3           # Probe N Zone 3
+sensor.thermomaven_[device]_probe_N_area_4           # Probe N Zone 4
+sensor.thermomaven_[device]_probe_N_area_5_handle    # Probe N Zone 5 (Handle)
 ```
 
 #### 🎛️ Climate Controls (v1.4.0+) ✨
@@ -155,8 +157,8 @@ sensor.thermomaven_[device]_wifi_signal      # WiFi signal (RSSI)
 #### 🌡️ Environment Sensors
 
 ```
-sensor.thermomaven_[device]_ambient          # Ambient temperature
-sensor.thermomaven_[device]_target           # Target temperature
+sensor.thermomaven_[device]_probe_N_ambient_temperature  # Ambient temperature at probe N handle
+sensor.thermomaven_[device]_target                        # Target temperature
 ```
 
 ## 💡 Usage Examples

--- a/custom_components/thermomaven/sensor.py
+++ b/custom_components/thermomaven/sensor.py
@@ -112,16 +112,20 @@ async def async_setup_entry(
                     )
                 )
             
-            for area_num in range(1, 6):
+            for probe_num in range(1, num_probes + 1):
+                for area_num in range(1, 6):
+                    entities_to_add.append(
+                        ThermoMavenAreaTemperatureSensor(
+                            coordinator, device, probe_num, area_num, entry.entry_id
+                        )
+                    )
+
+            for probe_num in range(1, num_probes + 1):
                 entities_to_add.append(
-                    ThermoMavenAreaTemperatureSensor(
-                        coordinator, device, area_num, entry.entry_id
+                    ThermoMavenAmbientTemperatureSensor(
+                        coordinator, device, probe_num, entry.entry_id
                     )
                 )
-            
-            entities_to_add.append(
-                ThermoMavenAmbientTemperatureSensor(coordinator, device, entry.entry_id)
-            )
             entities_to_add.append(
                 ThermoMavenTargetTemperatureSensor(coordinator, device, entry.entry_id)
             )
@@ -474,27 +478,28 @@ class ThermoMavenProbeBatterySensor(CoordinatorEntity, SensorEntity):
 
 
 class ThermoMavenAreaTemperatureSensor(CoordinatorEntity, SensorEntity):
-    """Representation of a ThermoMaven area temperature sensor (tip to handle)."""
+    """Representation of a ThermoMaven per-probe area temperature sensor (tip to handle)."""
 
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
 
-    def __init__(self, coordinator, device, area_num, entry_id):
+    def __init__(self, coordinator, device, probe_num, area_num, entry_id):
         """Initialize the sensor."""
         super().__init__(coordinator)
         self._device = device
+        self._probe_num = probe_num
         self._area_num = area_num
         self._device_id = device.get("deviceId")
         self._device_name = device.get("deviceName", "ThermoMaven")
         self._device_model = device.get("deviceModel", "Unknown")
-        
+
         area_labels = ["Area 1 Tip", "Area 2", "Area 3", "Area 4", "Area 5 Handle"]
         self._attr_has_entity_name = True
-        self._attr_name = area_labels[area_num - 1]
-        self._attr_translation_key = f"area_{area_num}"
-        self._attr_unique_id = f"{self._device_id}_area_{area_num}"
-        
+        self._attr_name = f"Probe {probe_num} {area_labels[area_num - 1]}"
+        self._attr_translation_key = f"probe_{probe_num}_area_{area_num}"
+        self._attr_unique_id = f"{self._device_id}_probe_{probe_num}_area_{area_num}"
+
         # Use helper function to create device info with diagnostic data
         self._attr_device_info = _create_device_info(device)
 
@@ -509,11 +514,12 @@ class ThermoMavenAreaTemperatureSensor(CoordinatorEntity, SensorEntity):
                     cmd_data = last_status.get("cmdData", {})
                     if cmd_data.get("globalStatus") != "online":
                         return None
-                    
+
                     probes = cmd_data.get("probes", [])
-                    if probes:
-                        probe_data = probes[0]
-                        area_temps = probe_data.get("areaTemperature", [])
+                    if self._probe_num <= len(probes):
+                        probe_data = probes[self._probe_num - 1]
+                        # areaTemperature is absent while the probe is docked/charging
+                        area_temps = probe_data.get("areaTemperature") or []
                         if len(area_temps) >= self._area_num:
                             temp_raw = area_temps[self._area_num - 1]
                             if temp_raw is not None:
@@ -535,25 +541,26 @@ class ThermoMavenAreaTemperatureSensor(CoordinatorEntity, SensorEntity):
 
 
 class ThermoMavenAmbientTemperatureSensor(CoordinatorEntity, SensorEntity):
-    """Representation of a ThermoMaven ambient temperature sensor."""
+    """Representation of a ThermoMaven per-probe ambient temperature sensor."""
 
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
 
-    def __init__(self, coordinator, device, entry_id):
+    def __init__(self, coordinator, device, probe_num, entry_id):
         """Initialize the sensor."""
         super().__init__(coordinator)
         self._device = device
+        self._probe_num = probe_num
         self._device_id = device.get("deviceId")
         self._device_name = device.get("deviceName", "ThermoMaven")
         self._device_model = device.get("deviceModel", "Unknown")
-        
+
         self._attr_has_entity_name = True
-        self._attr_name = "Ambient Temperature"
-        self._attr_translation_key = "ambient_temp"
-        self._attr_unique_id = f"{self._device_id}_ambient_temp"
-        
+        self._attr_name = f"Probe {probe_num} Ambient Temperature"
+        self._attr_translation_key = f"probe_{probe_num}_ambient_temp"
+        self._attr_unique_id = f"{self._device_id}_probe_{probe_num}_ambient_temp"
+
         # Use helper function to create device info with diagnostic data
         self._attr_device_info = _create_device_info(device)
 
@@ -568,10 +575,11 @@ class ThermoMavenAmbientTemperatureSensor(CoordinatorEntity, SensorEntity):
                     cmd_data = last_status.get("cmdData", {})
                     if cmd_data.get("globalStatus") != "online":
                         return None
-                    
+
                     probes = cmd_data.get("probes", [])
-                    if probes:
-                        probe_data = probes[0]
+                    if self._probe_num <= len(probes):
+                        probe_data = probes[self._probe_num - 1]
+                        # curAmbientTemperature is absent while the probe is docked/charging
                         temp_raw = probe_data.get("curAmbientTemperature")
                         if temp_raw is not None:
                             temp_f = temp_raw / 10.0

--- a/custom_components/thermomaven/translations/de.json
+++ b/custom_components/thermomaven/translations/de.json
@@ -49,23 +49,77 @@
       "probe_4_battery": {
         "name": "Batterie Sonde 4"
       },
-      "area_1": {
-        "name": "Bereich 1 Spitze"
+      "probe_1_area_1": {
+        "name": "Sonde 1 Bereich 1 Spitze"
       },
-      "area_2": {
-        "name": "Bereich 2"
+      "probe_1_area_2": {
+        "name": "Sonde 1 Bereich 2"
       },
-      "area_3": {
-        "name": "Bereich 3"
+      "probe_1_area_3": {
+        "name": "Sonde 1 Bereich 3"
       },
-      "area_4": {
-        "name": "Bereich 4"
+      "probe_1_area_4": {
+        "name": "Sonde 1 Bereich 4"
       },
-      "area_5": {
-        "name": "Bereich 5 Griff"
+      "probe_1_area_5": {
+        "name": "Sonde 1 Bereich 5 Griff"
       },
-      "ambient_temp": {
-        "name": "Umgebungstemperatur"
+      "probe_2_area_1": {
+        "name": "Sonde 2 Bereich 1 Spitze"
+      },
+      "probe_2_area_2": {
+        "name": "Sonde 2 Bereich 2"
+      },
+      "probe_2_area_3": {
+        "name": "Sonde 2 Bereich 3"
+      },
+      "probe_2_area_4": {
+        "name": "Sonde 2 Bereich 4"
+      },
+      "probe_2_area_5": {
+        "name": "Sonde 2 Bereich 5 Griff"
+      },
+      "probe_3_area_1": {
+        "name": "Sonde 3 Bereich 1 Spitze"
+      },
+      "probe_3_area_2": {
+        "name": "Sonde 3 Bereich 2"
+      },
+      "probe_3_area_3": {
+        "name": "Sonde 3 Bereich 3"
+      },
+      "probe_3_area_4": {
+        "name": "Sonde 3 Bereich 4"
+      },
+      "probe_3_area_5": {
+        "name": "Sonde 3 Bereich 5 Griff"
+      },
+      "probe_4_area_1": {
+        "name": "Sonde 4 Bereich 1 Spitze"
+      },
+      "probe_4_area_2": {
+        "name": "Sonde 4 Bereich 2"
+      },
+      "probe_4_area_3": {
+        "name": "Sonde 4 Bereich 3"
+      },
+      "probe_4_area_4": {
+        "name": "Sonde 4 Bereich 4"
+      },
+      "probe_4_area_5": {
+        "name": "Sonde 4 Bereich 5 Griff"
+      },
+      "probe_1_ambient_temp": {
+        "name": "Sonde 1 Umgebungstemperatur"
+      },
+      "probe_2_ambient_temp": {
+        "name": "Sonde 2 Umgebungstemperatur"
+      },
+      "probe_3_ambient_temp": {
+        "name": "Sonde 3 Umgebungstemperatur"
+      },
+      "probe_4_ambient_temp": {
+        "name": "Sonde 4 Umgebungstemperatur"
       },
       "target_temp": {
         "name": "Zieltemperatur"
@@ -98,4 +152,3 @@
     }
   }
 }
-

--- a/custom_components/thermomaven/translations/en.json
+++ b/custom_components/thermomaven/translations/en.json
@@ -49,23 +49,77 @@
       "probe_4_battery": {
         "name": "Probe 4 Battery"
       },
-      "area_1": {
-        "name": "Area 1 Tip"
+      "probe_1_area_1": {
+        "name": "Probe 1 Area 1 Tip"
       },
-      "area_2": {
-        "name": "Area 2"
+      "probe_1_area_2": {
+        "name": "Probe 1 Area 2"
       },
-      "area_3": {
-        "name": "Area 3"
+      "probe_1_area_3": {
+        "name": "Probe 1 Area 3"
       },
-      "area_4": {
-        "name": "Area 4"
+      "probe_1_area_4": {
+        "name": "Probe 1 Area 4"
       },
-      "area_5": {
-        "name": "Area 5 Handle"
+      "probe_1_area_5": {
+        "name": "Probe 1 Area 5 Handle"
       },
-      "ambient_temp": {
-        "name": "Ambient Temperature"
+      "probe_2_area_1": {
+        "name": "Probe 2 Area 1 Tip"
+      },
+      "probe_2_area_2": {
+        "name": "Probe 2 Area 2"
+      },
+      "probe_2_area_3": {
+        "name": "Probe 2 Area 3"
+      },
+      "probe_2_area_4": {
+        "name": "Probe 2 Area 4"
+      },
+      "probe_2_area_5": {
+        "name": "Probe 2 Area 5 Handle"
+      },
+      "probe_3_area_1": {
+        "name": "Probe 3 Area 1 Tip"
+      },
+      "probe_3_area_2": {
+        "name": "Probe 3 Area 2"
+      },
+      "probe_3_area_3": {
+        "name": "Probe 3 Area 3"
+      },
+      "probe_3_area_4": {
+        "name": "Probe 3 Area 4"
+      },
+      "probe_3_area_5": {
+        "name": "Probe 3 Area 5 Handle"
+      },
+      "probe_4_area_1": {
+        "name": "Probe 4 Area 1 Tip"
+      },
+      "probe_4_area_2": {
+        "name": "Probe 4 Area 2"
+      },
+      "probe_4_area_3": {
+        "name": "Probe 4 Area 3"
+      },
+      "probe_4_area_4": {
+        "name": "Probe 4 Area 4"
+      },
+      "probe_4_area_5": {
+        "name": "Probe 4 Area 5 Handle"
+      },
+      "probe_1_ambient_temp": {
+        "name": "Probe 1 Ambient Temperature"
+      },
+      "probe_2_ambient_temp": {
+        "name": "Probe 2 Ambient Temperature"
+      },
+      "probe_3_ambient_temp": {
+        "name": "Probe 3 Ambient Temperature"
+      },
+      "probe_4_ambient_temp": {
+        "name": "Probe 4 Ambient Temperature"
       },
       "target_temp": {
         "name": "Target Temperature"
@@ -112,4 +166,3 @@
     }
   }
 }
-

--- a/custom_components/thermomaven/translations/es.json
+++ b/custom_components/thermomaven/translations/es.json
@@ -49,23 +49,77 @@
       "probe_4_battery": {
         "name": "Batería Sonda 4"
       },
-      "area_1": {
-        "name": "Zona 1 Punta"
+      "probe_1_area_1": {
+        "name": "Sonda 1 Zona 1 Punta"
       },
-      "area_2": {
-        "name": "Zona 2"
+      "probe_1_area_2": {
+        "name": "Sonda 1 Zona 2"
       },
-      "area_3": {
-        "name": "Zona 3"
+      "probe_1_area_3": {
+        "name": "Sonda 1 Zona 3"
       },
-      "area_4": {
-        "name": "Zona 4"
+      "probe_1_area_4": {
+        "name": "Sonda 1 Zona 4"
       },
-      "area_5": {
-        "name": "Zona 5 Mango"
+      "probe_1_area_5": {
+        "name": "Sonda 1 Zona 5 Mango"
       },
-      "ambient_temp": {
-        "name": "Temperatura Ambiente"
+      "probe_2_area_1": {
+        "name": "Sonda 2 Zona 1 Punta"
+      },
+      "probe_2_area_2": {
+        "name": "Sonda 2 Zona 2"
+      },
+      "probe_2_area_3": {
+        "name": "Sonda 2 Zona 3"
+      },
+      "probe_2_area_4": {
+        "name": "Sonda 2 Zona 4"
+      },
+      "probe_2_area_5": {
+        "name": "Sonda 2 Zona 5 Mango"
+      },
+      "probe_3_area_1": {
+        "name": "Sonda 3 Zona 1 Punta"
+      },
+      "probe_3_area_2": {
+        "name": "Sonda 3 Zona 2"
+      },
+      "probe_3_area_3": {
+        "name": "Sonda 3 Zona 3"
+      },
+      "probe_3_area_4": {
+        "name": "Sonda 3 Zona 4"
+      },
+      "probe_3_area_5": {
+        "name": "Sonda 3 Zona 5 Mango"
+      },
+      "probe_4_area_1": {
+        "name": "Sonda 4 Zona 1 Punta"
+      },
+      "probe_4_area_2": {
+        "name": "Sonda 4 Zona 2"
+      },
+      "probe_4_area_3": {
+        "name": "Sonda 4 Zona 3"
+      },
+      "probe_4_area_4": {
+        "name": "Sonda 4 Zona 4"
+      },
+      "probe_4_area_5": {
+        "name": "Sonda 4 Zona 5 Mango"
+      },
+      "probe_1_ambient_temp": {
+        "name": "Sonda 1 Temperatura Ambiente"
+      },
+      "probe_2_ambient_temp": {
+        "name": "Sonda 2 Temperatura Ambiente"
+      },
+      "probe_3_ambient_temp": {
+        "name": "Sonda 3 Temperatura Ambiente"
+      },
+      "probe_4_ambient_temp": {
+        "name": "Sonda 4 Temperatura Ambiente"
       },
       "target_temp": {
         "name": "Temperatura Objetivo"
@@ -98,4 +152,3 @@
     }
   }
 }
-

--- a/custom_components/thermomaven/translations/fr.json
+++ b/custom_components/thermomaven/translations/fr.json
@@ -49,23 +49,77 @@
       "probe_4_battery": {
         "name": "Batterie Sonde 4"
       },
-      "area_1": {
-        "name": "Zone 1 Pointe"
+      "probe_1_area_1": {
+        "name": "Sonde 1 Zone 1 Pointe"
       },
-      "area_2": {
-        "name": "Zone 2"
+      "probe_1_area_2": {
+        "name": "Sonde 1 Zone 2"
       },
-      "area_3": {
-        "name": "Zone 3"
+      "probe_1_area_3": {
+        "name": "Sonde 1 Zone 3"
       },
-      "area_4": {
-        "name": "Zone 4"
+      "probe_1_area_4": {
+        "name": "Sonde 1 Zone 4"
       },
-      "area_5": {
-        "name": "Zone 5 Poignée"
+      "probe_1_area_5": {
+        "name": "Sonde 1 Zone 5 Poignée"
       },
-      "ambient_temp": {
-        "name": "Température Ambiante"
+      "probe_2_area_1": {
+        "name": "Sonde 2 Zone 1 Pointe"
+      },
+      "probe_2_area_2": {
+        "name": "Sonde 2 Zone 2"
+      },
+      "probe_2_area_3": {
+        "name": "Sonde 2 Zone 3"
+      },
+      "probe_2_area_4": {
+        "name": "Sonde 2 Zone 4"
+      },
+      "probe_2_area_5": {
+        "name": "Sonde 2 Zone 5 Poignée"
+      },
+      "probe_3_area_1": {
+        "name": "Sonde 3 Zone 1 Pointe"
+      },
+      "probe_3_area_2": {
+        "name": "Sonde 3 Zone 2"
+      },
+      "probe_3_area_3": {
+        "name": "Sonde 3 Zone 3"
+      },
+      "probe_3_area_4": {
+        "name": "Sonde 3 Zone 4"
+      },
+      "probe_3_area_5": {
+        "name": "Sonde 3 Zone 5 Poignée"
+      },
+      "probe_4_area_1": {
+        "name": "Sonde 4 Zone 1 Pointe"
+      },
+      "probe_4_area_2": {
+        "name": "Sonde 4 Zone 2"
+      },
+      "probe_4_area_3": {
+        "name": "Sonde 4 Zone 3"
+      },
+      "probe_4_area_4": {
+        "name": "Sonde 4 Zone 4"
+      },
+      "probe_4_area_5": {
+        "name": "Sonde 4 Zone 5 Poignée"
+      },
+      "probe_1_ambient_temp": {
+        "name": "Sonde 1 Température Ambiante"
+      },
+      "probe_2_ambient_temp": {
+        "name": "Sonde 2 Température Ambiante"
+      },
+      "probe_3_ambient_temp": {
+        "name": "Sonde 3 Température Ambiante"
+      },
+      "probe_4_ambient_temp": {
+        "name": "Sonde 4 Température Ambiante"
       },
       "target_temp": {
         "name": "Température Cible"

--- a/custom_components/thermomaven/translations/pt.json
+++ b/custom_components/thermomaven/translations/pt.json
@@ -49,23 +49,77 @@
       "probe_4_battery": {
         "name": "Bateria Sonda 4"
       },
-      "area_1": {
-        "name": "Zona 1 Ponta"
+      "probe_1_area_1": {
+        "name": "Sonda 1 Zona 1 Ponta"
       },
-      "area_2": {
-        "name": "Zona 2"
+      "probe_1_area_2": {
+        "name": "Sonda 1 Zona 2"
       },
-      "area_3": {
-        "name": "Zona 3"
+      "probe_1_area_3": {
+        "name": "Sonda 1 Zona 3"
       },
-      "area_4": {
-        "name": "Zona 4"
+      "probe_1_area_4": {
+        "name": "Sonda 1 Zona 4"
       },
-      "area_5": {
-        "name": "Zona 5 Cabo"
+      "probe_1_area_5": {
+        "name": "Sonda 1 Zona 5 Cabo"
       },
-      "ambient_temp": {
-        "name": "Temperatura Ambiente"
+      "probe_2_area_1": {
+        "name": "Sonda 2 Zona 1 Ponta"
+      },
+      "probe_2_area_2": {
+        "name": "Sonda 2 Zona 2"
+      },
+      "probe_2_area_3": {
+        "name": "Sonda 2 Zona 3"
+      },
+      "probe_2_area_4": {
+        "name": "Sonda 2 Zona 4"
+      },
+      "probe_2_area_5": {
+        "name": "Sonda 2 Zona 5 Cabo"
+      },
+      "probe_3_area_1": {
+        "name": "Sonda 3 Zona 1 Ponta"
+      },
+      "probe_3_area_2": {
+        "name": "Sonda 3 Zona 2"
+      },
+      "probe_3_area_3": {
+        "name": "Sonda 3 Zona 3"
+      },
+      "probe_3_area_4": {
+        "name": "Sonda 3 Zona 4"
+      },
+      "probe_3_area_5": {
+        "name": "Sonda 3 Zona 5 Cabo"
+      },
+      "probe_4_area_1": {
+        "name": "Sonda 4 Zona 1 Ponta"
+      },
+      "probe_4_area_2": {
+        "name": "Sonda 4 Zona 2"
+      },
+      "probe_4_area_3": {
+        "name": "Sonda 4 Zona 3"
+      },
+      "probe_4_area_4": {
+        "name": "Sonda 4 Zona 4"
+      },
+      "probe_4_area_5": {
+        "name": "Sonda 4 Zona 5 Cabo"
+      },
+      "probe_1_ambient_temp": {
+        "name": "Sonda 1 Temperatura Ambiente"
+      },
+      "probe_2_ambient_temp": {
+        "name": "Sonda 2 Temperatura Ambiente"
+      },
+      "probe_3_ambient_temp": {
+        "name": "Sonda 3 Temperatura Ambiente"
+      },
+      "probe_4_ambient_temp": {
+        "name": "Sonda 4 Temperatura Ambiente"
       },
       "target_temp": {
         "name": "Temperatura Alvo"
@@ -98,4 +152,3 @@
     }
   }
 }
-

--- a/custom_components/thermomaven/translations/zh-Hans.json
+++ b/custom_components/thermomaven/translations/zh-Hans.json
@@ -49,23 +49,77 @@
       "probe_4_battery": {
         "name": "探头 4 电池"
       },
-      "area_1": {
-        "name": "区域 1 尖端"
+      "probe_1_area_1": {
+        "name": "探头 1 区域 1 尖端"
       },
-      "area_2": {
-        "name": "区域 2"
+      "probe_1_area_2": {
+        "name": "探头 1 区域 2"
       },
-      "area_3": {
-        "name": "区域 3"
+      "probe_1_area_3": {
+        "name": "探头 1 区域 3"
       },
-      "area_4": {
-        "name": "区域 4"
+      "probe_1_area_4": {
+        "name": "探头 1 区域 4"
       },
-      "area_5": {
-        "name": "区域 5 手柄"
+      "probe_1_area_5": {
+        "name": "探头 1 区域 5 手柄"
       },
-      "ambient_temp": {
-        "name": "环境温度"
+      "probe_2_area_1": {
+        "name": "探头 2 区域 1 尖端"
+      },
+      "probe_2_area_2": {
+        "name": "探头 2 区域 2"
+      },
+      "probe_2_area_3": {
+        "name": "探头 2 区域 3"
+      },
+      "probe_2_area_4": {
+        "name": "探头 2 区域 4"
+      },
+      "probe_2_area_5": {
+        "name": "探头 2 区域 5 手柄"
+      },
+      "probe_3_area_1": {
+        "name": "探头 3 区域 1 尖端"
+      },
+      "probe_3_area_2": {
+        "name": "探头 3 区域 2"
+      },
+      "probe_3_area_3": {
+        "name": "探头 3 区域 3"
+      },
+      "probe_3_area_4": {
+        "name": "探头 3 区域 4"
+      },
+      "probe_3_area_5": {
+        "name": "探头 3 区域 5 手柄"
+      },
+      "probe_4_area_1": {
+        "name": "探头 4 区域 1 尖端"
+      },
+      "probe_4_area_2": {
+        "name": "探头 4 区域 2"
+      },
+      "probe_4_area_3": {
+        "name": "探头 4 区域 3"
+      },
+      "probe_4_area_4": {
+        "name": "探头 4 区域 4"
+      },
+      "probe_4_area_5": {
+        "name": "探头 4 区域 5 手柄"
+      },
+      "probe_1_ambient_temp": {
+        "name": "探头 1 环境温度"
+      },
+      "probe_2_ambient_temp": {
+        "name": "探头 2 环境温度"
+      },
+      "probe_3_ambient_temp": {
+        "name": "探头 3 环境温度"
+      },
+      "probe_4_ambient_temp": {
+        "name": "探头 4 环境温度"
       },
       "target_temp": {
         "name": "目标温度"
@@ -98,4 +152,3 @@
     }
   }
 }
-


### PR DESCRIPTION
## Problem

`ThermoMavenAreaTemperatureSensor` and `ThermoMavenAmbientTemperatureSensor` are created once per **device** and always read `probes[0]`:

```python
probes = cmd_data.get("probes", [])
if probes:
    probe_data = probes[0]
```

Two consequences on multi-probe devices (G2/P2/G4/P4):

1. Only probe 1's five `areaTemperature` zones and `curAmbientTemperature` are exposed — the same per-probe data for probes 2–4 is silently dropped (#5, #6). The README already promises "Zone Sensors (for each probe)", so this brings the code in line with the docs.
2. Whenever probe 1 sits docked in the charger, the device omits its temperature fields, so **all** area/ambient sensors go `unknown` — even while other probes are deployed and reporting.

I hit case 2 on a WT09/G4 during an 18.5 lb turkey cook: probes 3+4 were in the bird for hours reporting fine, but ambient + all area entities stayed `unknown` until probe 1 happened to be deployed — at which point they showed probe 1's zones, not anything device-level.

## Change

- One set of `Area 1 Tip … Area 5 Handle` sensors **per probe**, plus one `Ambient Temperature` sensor **per probe**, indexed with the same `probes[self._probe_num - 1]` convention `ThermoMavenTemperatureSensor` and `ThermoMavenProbeBatterySensor` already use.
- A docked probe reports `None` for its own sensors (fields absent while charging) without affecting the other probes.
- New unique_ids: `{device_id}_probe_{p}_area_{n}` / `{device_id}_probe_{p}_ambient_temp`. Since `async_setup_entry` already removes and recreates this integration's registry entries on every setup, the old device-level entities clean themselves up on upgrade.
- Translation keys (`probe_{p}_area_{n}`, `probe_{p}_ambient_temp`) added to all six language files, composed from each language's existing probe/area/ambient strings — a native speaker may want to double-check word order, especially zh-Hans.
- README entity list updated.

## Testing

- `python3 -m py_compile` clean.
- Exercised the sensor classes standalone against a captured-shape G4 payload (probes 1–2 docked/sparse, probes 3–4 deployed): correct per-probe zone/ambient values in °C, `None` for docked probes, `available` stays true, 24 distinct unique_ids, offline device returns `None`.
- I can validate on live hardware (WT09/G4) after my current cook finishes, if useful.

Note: `target_temperature` and the cook-time/mode/state sensors have the same `probes[0]` pattern — left untouched here to keep this focused on #5/#6, but happy to extend the same treatment in a follow-up if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)